### PR TITLE
fix nix on darwin

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -24,6 +24,7 @@ let
        rev = "release_${version}";
       sha256 = "sha256-OayULh/dGI5sEynYMc+JLwUd67zEGdIGEKo6CTOdZS8=";
     };
+    meta = old.meta // { broken = false; };
   });
 
   # pymks


### PR DESCRIPTION
Fix nix build in the Darwin environment by turning off "broken". This
needs to be repaired in Nixpkgs.